### PR TITLE
Adds env ADMIN_PASSWORD to hide admin info

### DIFF
--- a/data/seeds/003-users.js
+++ b/data/seeds/003-users.js
@@ -19,7 +19,7 @@ const seed_data = [
   {
     // id: 4,
     username: 'adminUser',
-    password: `${bcrypt.hashSync('when i was a young boy my father took me into the city all lowercase with no punctuation', 8)}`
+    password: `${bcrypt.hashSync(process.env.ADMIN_PASSWORD, 8)}`
   }
 ]
 exports.users_data = seed_data


### PR DESCRIPTION
Make sure to add `ADMIN_PASSWORD` to your .env vile when testing the server locally!